### PR TITLE
Add docker in tools to use local images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY files/etc/luet/luet.yaml /etc/luet/luet.yaml
 
 FROM base as tools
 ENV LUET_NOLOCK=true
-RUN zypper in -y squashfs xorriso
+RUN zypper in -y docker squashfs xorriso
 COPY tools /
 RUN luet install -y toolchain/luet-makeiso
 


### PR DESCRIPTION
Add docker back, it's needed to probe if an image exists locally.
context:
https://github.com/mudler/luet-makeiso/blob/99672eea4ac386b1702a9aef9d60eec3b262fe60/pkg/burner/burner.go#L90-L96
https://github.com/mudler/luet-makeiso/blob/99672eea4ac386b1702a9aef9d60eec3b262fe60/pkg/burner/docker.go#L8-L15